### PR TITLE
Test Case RMLFNOTC0011-CSV

### DIFF
--- a/test-cases/RMLFNOTC0011-CSV/mapping.ttl
+++ b/test-cases/RMLFNOTC0011-CSV/mapping.ttl
@@ -29,17 +29,16 @@
     ] .
 
 <#Execution>
-    rml:function grel:string_substring ; # https://github.com/kg-construct/BURP/blob/c89eb9a989d9f2761ec11e63f8d2a522775c4cb9/src/main/java/burp/model/fnmlutil/Functions.java#L530
+    rml:function grel:string_substring ;
     rml:input
         [
             rml:parameter grel:valueParam ;
             rml:inputValueMap [
-                rml:reference "Name" ;
-            ]
-        ] .
+                rml:reference "Name"
+            ];
+        ]  ,
         [
-            rml:parameter grel:param_int_i_from ;
-            rml:inputValueMap [
-                  rr:constant 1
-            ]
-        ] .
+            a rml:Input ;
+            rml:parameter grel:p_int_i_from ;
+            rml:inputValue "1000"
+        ]  .

--- a/test-cases/RMLFNOTC0011-CSV/mapping.ttl
+++ b/test-cases/RMLFNOTC0011-CSV/mapping.ttl
@@ -1,0 +1,45 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://w3id.org/rml/> .
+@prefix fno: <https://w3id.org/function/ontology#> .
+@prefix morph-kgc: <https://github.com/morph-kgc/morph-kgc/function/built-in.ttl#> .
+@prefix grel: <http://users.ugent.be/~bjdmeest/function/grel.ttl#> .
+@prefix idlab-fn: <http://example.com/idlab/function/> .
+@prefix rr: <http://www.w3.org/ns/r2rml#>.
+
+@base <http://example.com/base/> .
+
+<TriplesMap1>
+    rml:logicalSource [
+        rml:source [ a rml:RelativePathSource;
+          rml:root rml:MappingDirectory;
+          rml:path "student.csv"
+        ];
+        rml:referenceFormulation rml:CSV
+    ];
+    rml:subjectMap [
+        rml:template "http://example.com/{Name}"
+    ];
+    rml:predicateObjectMap [
+        rml:predicate foaf:name;
+        rml:objectMap [
+            rml:functionExecution <#Execution> ;
+        ]
+    ] .
+
+<#Execution>
+    rml:function grel:string_substring ; # https://github.com/kg-construct/BURP/blob/c89eb9a989d9f2761ec11e63f8d2a522775c4cb9/src/main/java/burp/model/fnmlutil/Functions.java#L530
+    rml:input
+        [
+            rml:parameter grel:valueParam ;
+            rml:inputValueMap [
+                rml:reference "Name" ;
+            ]
+        ] .
+        [
+            rml:parameter grel:param_int_i_from ;
+            rml:inputValueMap [
+                  rr:constant 1
+            ]
+        ] .

--- a/test-cases/RMLFNOTC0011-CSV/student.csv
+++ b/test-cases/RMLFNOTC0011-CSV/student.csv
@@ -1,0 +1,2 @@
+Id,Name,Comment,Class
+1,Venus,A&B,A


### PR DESCRIPTION
### Title
Function on object returns null	

### Purpose
Tests that no triple should be generated when the result is null.

### Comment
This test should not produce any result so the expected output is empty (no triples are generated)

I decided to use the `grel:string_substring` function in combination with a `from` param that exceeds the length of the given string. When I run this test with BURP, it crashes because of an unhandled `StringIndexOutOfBoundsException`. Looking at [GREL](https://openrefine.org/docs/manual/grelfunctions#substrings-n-from-n-to-optional), I am not sure what the expected output is, but `null` seems sensible and rather preferable over an empty string.   